### PR TITLE
fix: show error when feed has no webhooks configured

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -15,5 +15,5 @@ url = "https://discord.com/api/webhooks/XXX/YYY"
 [[feeds]]
 name = "NYT"
 url = "https://rss.nytimes.com/services/xml/rss/nyt/HomePage.xml"
-webhook = "Hook-1"
+webhooks = ["Hook-1"]
 # disabled = false

--- a/internal/app/config/config.go
+++ b/internal/app/config/config.go
@@ -103,7 +103,10 @@ func parseConfig(config *Config) error {
 	webhooksUsed := make(map[string]bool)
 	for _, x := range config.Feeds {
 		if x.Name == "" {
-			return fmt.Errorf("one feed has no name")
+			return fmt.Errorf("feed has no name")
+		}
+		if len(x.Webhooks) == 0 {
+			return fmt.Errorf("feed %s has no webhooks", x.Name)
 		}
 		if x.URL == "" {
 			return fmt.Errorf("feed %s has no url", x.Name)

--- a/internal/app/config/config_internal_test.go
+++ b/internal/app/config/config_internal_test.go
@@ -40,6 +40,13 @@ func TestParseConfig(t *testing.T) {
 		}
 		assert.Error(t, parseConfig(&cf))
 	})
+	t.Run("should return error when feed has no webhook", func(t *testing.T) {
+		cf := Config{
+			Webhooks: []ConfigWebhook{{Name: "hook", URL: "https://www.example.com/url1"}},
+			Feeds:    []ConfigFeed{{Name: "feed", URL: "https://www.example.com/url2"}},
+		}
+		assert.Error(t, parseConfig(&cf))
+	})
 	t.Run("should return error when feed has no https://www.example.com/url", func(t *testing.T) {
 		cf := Config{
 			Webhooks: []ConfigWebhook{{Name: "hook", URL: "https://www.example.com/url1"}},

--- a/internal/app/dispatcher/dispatcher.go
+++ b/internal/app/dispatcher/dispatcher.go
@@ -131,6 +131,10 @@ func (d *Dispatcher) Start() error {
 	main:
 		for {
 			for _, cf := range feeds {
+				if len(cf.Webhooks) == 0 {
+					slog.Warn("Skipping feed without webhooks", "name", cf.Name)
+					continue
+				}
 				wg.Add(1)
 				go func() {
 					defer wg.Done()


### PR DESCRIPTION
When no webhook was configured for a feed it would still start and receive messages, but never send any.

Also the example config file still had the outdated syntax for defining webhooks, which led to an invalid configuration, but was not shown as error.

With this fix feed's without a webhook generate a config error and the example config file is corrected.